### PR TITLE
feat: derive Eq and PartialEq for EntryKind

### DIFF
--- a/rc-zip/src/parse/archive.rs
+++ b/rc-zip/src/parse/archive.rs
@@ -237,7 +237,7 @@ impl Entry {
 }
 
 /// The entry's file type: a directory, a file, or a symbolic link.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum EntryKind {
     /// The entry is a directory
     Directory,


### PR DESCRIPTION
Simple fix to allow for comparing of EntryKinds, could use a match statement or matches! macro (or similar) but I think having Eq traits derived is nicer.