### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,7 +769,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rc-zip"
-version = "5.2.0"
+version = "5.3.0"
 dependencies = [
  "bzip2",
  "chardetng",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "rc-zip-cli"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if",
  "clap",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "rc-zip-sync"
-version = "4.2.4"
+version = "4.2.5"
 dependencies = [
  "oval",
  "positioned-io",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "rc-zip-tokio"
-version = "4.2.3"
+version = "4.2.4"
 dependencies = [
  "futures-util",
  "oval",

--- a/rc-zip-cli/CHANGELOG.md
+++ b/rc-zip-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1](https://github.com/bearcove/rc-zip/compare/rc-zip-cli-v1.1.0...rc-zip-cli-v1.1.1) - 2025-02-05
+
+### Other
+
+- updated the following local packages: rc-zip
+
 ## [1.1.0](https://github.com/bearcove/rc-zip/compare/rc-zip-cli-v1.0.1...rc-zip-cli-v1.1.0) - 2024-12-17
 
 ### Added

--- a/rc-zip-cli/Cargo.toml
+++ b/rc-zip-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc-zip-cli"
-version = "1.1.0"
+version = "1.1.1"
 description = "A sample zip decompressor based on rc-zip"
 license = "Apache-2.0 OR MIT"
 authors = ["Amos Wenger <amoswenger@gmail.com>"]
@@ -19,8 +19,8 @@ name = "rc-zip-cli"
 path = "src/main.rs"
 
 [dependencies]
-rc-zip = { version = "5.2.0", path = "../rc-zip", features = ["corpus"] }
-rc-zip-sync = { version = "4.2.4", path = "../rc-zip-sync", features = [
+rc-zip = { version = "5.3.0", path = "../rc-zip", features = ["corpus"] }
+rc-zip-sync = { version = "4.2.5", path = "../rc-zip-sync", features = [
     "bzip2",
     "deflate64",
     "lzma",

--- a/rc-zip-sync/CHANGELOG.md
+++ b/rc-zip-sync/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.5](https://github.com/bearcove/rc-zip/compare/rc-zip-sync-v4.2.4...rc-zip-sync-v4.2.5) - 2025-02-05
+
+### Other
+
+- updated the following local packages: rc-zip
+
 ## [4.2.4](https://github.com/bearcove/rc-zip/compare/rc-zip-sync-v4.2.3...rc-zip-sync-v4.2.4) - 2024-12-17
 
 ### Other

--- a/rc-zip-sync/Cargo.toml
+++ b/rc-zip-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc-zip-sync"
-version = "4.2.4"
+version = "4.2.5"
 description = "Synchronous zip reading on top of rc-zip"
 repository = "https://github.com/fasterthanlime/rc-zip"
 license = "Apache-2.0 OR MIT"
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 positioned-io = { version = "0.3.3", optional = true }
-rc-zip = { version = "5.2.0", path = "../rc-zip" }
+rc-zip = { version = "5.3.0", path = "../rc-zip" }
 oval = "2.0.0"
 tracing = "0.1.40"
 

--- a/rc-zip-tokio/CHANGELOG.md
+++ b/rc-zip-tokio/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.4](https://github.com/bearcove/rc-zip/compare/rc-zip-tokio-v4.2.3...rc-zip-tokio-v4.2.4) - 2025-02-05
+
+### Other
+
+- updated the following local packages: rc-zip, rc-zip
+
 ## [4.2.3](https://github.com/bearcove/rc-zip/compare/rc-zip-tokio-v4.2.2...rc-zip-tokio-v4.2.3) - 2024-12-17
 
 ### Other

--- a/rc-zip-tokio/Cargo.toml
+++ b/rc-zip-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc-zip-tokio"
-version = "4.2.3"
+version = "4.2.4"
 description = "Asynchronous zip reading on top of rc-zip (for tokio I/O traits)"
 repository = "https://github.com/fasterthanlime/rc-zip"
 license = "Apache-2.0 OR MIT"
@@ -17,7 +17,7 @@ name = "rc_zip_tokio"
 path = "src/lib.rs"
 
 [dependencies]
-rc-zip = { version = "5.2.0", path = "../rc-zip" }
+rc-zip = { version = "5.3.0", path = "../rc-zip" }
 positioned-io = { version = "0.3.3" }
 tokio = { version = "1.35.1", features = ["fs", "io-util", "rt-multi-thread"] }
 futures-util = { version = "0.3.30" }
@@ -34,5 +34,5 @@ bzip2 = ["rc-zip/bzip2"]
 zstd = ["rc-zip/zstd"]
 
 [dev-dependencies]
-rc-zip = { version = "5.2.0", path = "../rc-zip", features = ["corpus"] }
+rc-zip = { version = "5.3.0", path = "../rc-zip", features = ["corpus"] }
 tokio = { version = "1.35.1", features = ["rt", "macros"] }

--- a/rc-zip/CHANGELOG.md
+++ b/rc-zip/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.3.0](https://github.com/bearcove/rc-zip/compare/rc-zip-v5.2.0...rc-zip-v5.3.0) - 2025-02-05
+
+### Added
+
+- derive Eq and PartialEq for EntryKind (#95)
+
 ## [5.2.0](https://github.com/bearcove/rc-zip/compare/rc-zip-v5.1.3...rc-zip-v5.2.0) - 2024-12-17
 
 ### Added

--- a/rc-zip/Cargo.toml
+++ b/rc-zip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc-zip"
-version = "5.2.0"
+version = "5.3.0"
 description = "An I/O-agnostic implementation of the zip file format"
 repository = "https://github.com/fasterthanlime/rc-zip"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION



## 🤖 New release

* `rc-zip`: 5.3.0
* `rc-zip-cli`: 1.1.1
* `rc-zip-sync`: 4.2.5
* `rc-zip-tokio`: 4.2.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `rc-zip`

<blockquote>

## [5.3.0](https://github.com/bearcove/rc-zip/compare/rc-zip-v5.2.0...rc-zip-v5.3.0) - 2025-02-05

### Added

- derive Eq and PartialEq for EntryKind (#95)
</blockquote>

## `rc-zip-cli`

<blockquote>

## [1.1.1](https://github.com/bearcove/rc-zip/compare/rc-zip-cli-v1.1.0...rc-zip-cli-v1.1.1) - 2025-02-05

### Other

- updated the following local packages: rc-zip
</blockquote>

## `rc-zip-sync`

<blockquote>

## [4.2.5](https://github.com/bearcove/rc-zip/compare/rc-zip-sync-v4.2.4...rc-zip-sync-v4.2.5) - 2025-02-05

### Other

- updated the following local packages: rc-zip
</blockquote>

## `rc-zip-tokio`

<blockquote>

## [4.2.4](https://github.com/bearcove/rc-zip/compare/rc-zip-tokio-v4.2.3...rc-zip-tokio-v4.2.4) - 2025-02-05

### Other

- updated the following local packages: rc-zip, rc-zip
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).